### PR TITLE
Show teams, redirect to practice by team, check access for pratice

### DIFF
--- a/src/main/java/com/company/simulator/controller/PracticeController.java
+++ b/src/main/java/com/company/simulator/controller/PracticeController.java
@@ -2,11 +2,14 @@ package com.company.simulator.controller;
 
 import com.company.simulator.model.Category;
 import com.company.simulator.model.Practice;
+import com.company.simulator.model.Student;
 import com.company.simulator.model.Submission;
 import com.company.simulator.model.Task;
+import com.company.simulator.model.Team;
 import com.company.simulator.model.User;
 import com.company.simulator.repos.CategoryRepo;
 import com.company.simulator.repos.PracticeRepo;
+import com.company.simulator.repos.StudentRepo;
 import com.company.simulator.repos.SubmissionRepo;
 import com.company.simulator.repos.TaskRepo;
 import java.util.ArrayList;
@@ -14,14 +17,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -40,10 +42,27 @@ public final class PracticeController {
     @Autowired
     private TaskRepo taskRepo;
 
+    @Autowired
+    private StudentRepo studentRepo;
+
     @GetMapping("/practice")
-    public String allPractices(Model model) {
-        final Iterable<Practice> practices = practiceRepo.findAllByIdIsNot(Practice.COMMON_POOL);
+    public String availablePractices(
+        Model model,
+        @RequestParam(required = false) Team team,
+        @RequestParam(required = false) String result,
+        @RequestParam(required = false) String type
+    ) {
+        final Iterable<Practice> practices;
+        if (team == null) {
+            practices = practiceRepo.findAllByIdIsNot(Practice.COMMON_POOL);
+        } else {
+            practices = team.getPractices().stream()
+                .filter(prac -> !prac.getId().equals(Practice.COMMON_POOL))
+                .collect(Collectors.toList());
+        }
         model.addAttribute("practices", practices);
+        model.addAttribute("result", result);
+        model.addAttribute("type", type);
         return "practice/practiceList";
     }
 
@@ -57,27 +76,51 @@ public final class PracticeController {
         @RequestParam(required = false) String type,
         Model model
     ) {
-        final Collection<Task> tasks;
-        model.addAttribute("categories", categoryRepo.findAll());
-        model.addAttribute("practice", practice);
-        model.addAttribute("result", result);
-        model.addAttribute("type", type);
-        final String template;
-        if (practice.getId().equals(Practice.COMMON_POOL)) {
-            if (category != null) {
-                tasks = taskRepo.findAllByCategoryAndPractice(category.getId(), practice.getId());
-                model.addAttribute("category_filter", category);
+        if (hasAccess(user, practice)) {
+            final Collection<Task> tasks;
+            model.addAttribute("categories", categoryRepo.findAll());
+            model.addAttribute("practice", practice);
+            model.addAttribute("result", result);
+            model.addAttribute("type", type);
+            final String template;
+            if (practice.getId().equals(Practice.COMMON_POOL)) {
+                if (category != null) {
+                    tasks = taskRepo.findAllByCategoryAndPractice(category.getId(), practice.getId());
+                    model.addAttribute("category_filter", category);
+                } else {
+                    tasks = practice.getTasks();
+                }
+                template = "practice/commonPool";
             } else {
                 tasks = practice.getTasks();
+                template = "practice/tasksByPractice";
             }
-            template = "practice/commonPool";
+            final List<Task> markedTasks = tasksWithMarkedStatus(tasks, practice, user);
+            model.addAttribute("tasks", filterTasksByStatus(markedTasks, task_status));
+            return template;
         } else {
-            tasks = practice.getTasks();
-            template = "practice/tasksByPractice";
+            model.addAttribute(
+                "result",
+                String.format("Access to practice `%d` denied", practice.getId())
+            );
+            model.addAttribute("type", "danger");
+            model.addAttribute("practices", practiceRepo.findAllByIdIsNot(Practice.COMMON_POOL));
+            return "practice/practiceList";
         }
-        final List<Task> markedTasks = tasksWithMarkedStatus(tasks, practice, user);
-        model.addAttribute("tasks", filterTasksByStatus(markedTasks, task_status));
-        return template;
+    }
+
+    private boolean hasAccess(User user, Practice practice) {
+        boolean allowed = false;
+        final Set<Team> teams = practice.getTeams();
+        final List<Student> students = studentRepo.findAllByUserId(user.getId())
+            .orElseGet(ArrayList::new);
+        for (Student student: students) {
+            if (teams.contains(student.getTeam())) {
+                allowed = true;
+                break;
+            }
+        }
+        return allowed;
     }
 
     private Collection<Task> filterTasksByStatus(Collection<Task> tasks, String status) {

--- a/src/main/java/com/company/simulator/model/Team.java
+++ b/src/main/java/com/company/simulator/model/Team.java
@@ -1,13 +1,13 @@
 package com.company.simulator.model;
 
 import java.util.Set;
-import javax.persistence.CollectionTable;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -17,15 +17,15 @@ import lombok.ToString;
 @Entity
 @NoArgsConstructor
 @EqualsAndHashCode(of = {"id"})
-@ToString(of = {"id", "authorId", "invitation", "name"})
+@ToString(of = {"id", "author", "invitation", "name"})
 @Data
 public class Team {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @CollectionTable(name = "person", joinColumns = @JoinColumn(name = "user_id"))
-    private Long authorId;
+    @ManyToOne(fetch = FetchType.EAGER)
+    private User author;
 
     private String name;
 

--- a/src/main/java/com/company/simulator/repos/StudentRepo.java
+++ b/src/main/java/com/company/simulator/repos/StudentRepo.java
@@ -1,7 +1,10 @@
 package com.company.simulator.repos;
 
 import com.company.simulator.model.Student;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
 public interface StudentRepo extends CrudRepository<Student, Long> {
+    Optional<List<Student>> findAllByUserId(Long user);
 }

--- a/src/main/java/com/company/simulator/repos/TeamRepo.java
+++ b/src/main/java/com/company/simulator/repos/TeamRepo.java
@@ -17,6 +17,14 @@ public interface TeamRepo extends CrudRepository<Team, Long> {
     Optional<List<Team>> findTeamsByPracticesContains(Practice practice);
     Optional<List<Team>> findTeamsByPracticesNotContainsAndAuthorId(Practice practice, Long id);
 
+    @Query(
+        value = "SELECT * FROM team t " +
+                    "JOIN student s on t.id = s.team_id " +
+                    "WHERE s.user_id = ?1",
+        nativeQuery = true
+    )
+    Optional<List<Team>> findTeamsByStudentId(Long student);
+
     @Modifying
     @Query(
             value = "INSERT INTO practice_x_team (practice_id, team_id) values (:practiceId, :teamId)",

--- a/src/main/resources/templates/parts/navbar.ftlh
+++ b/src/main/resources/templates/parts/navbar.ftlh
@@ -1,7 +1,7 @@
 <#include "security.ftlh">
 <#import "authentication.ftlh" as auth>
 
-<nav class="navbar navbar-expand-lg navbar-light bg-light">
+<nav class="navbar nav-tabs navbar-expand-lg navbar-light bg-light">
     <a class="navbar-brand" href="/">Sql-simulator</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">

--- a/src/main/resources/templates/practice/practiceList.ftlh
+++ b/src/main/resources/templates/practice/practiceList.ftlh
@@ -2,6 +2,7 @@
 <#include "../parts/security.ftlh">
 
 <@c.page>
+    <#include "../parts/alertResult.ftlh"/>
     <p class="text-dark h5">Available practices</p>
     <div class="card-columns">
         <#list practices as practice>

--- a/src/main/resources/templates/result.ftlh
+++ b/src/main/resources/templates/result.ftlh
@@ -1,0 +1,6 @@
+<#import "parts/common.ftlh" as c>
+<#import "parts/authentication.ftlh" as auth>
+
+<@c.page>
+
+</@c.page>

--- a/src/main/resources/templates/team.ftlh
+++ b/src/main/resources/templates/team.ftlh
@@ -1,4 +1,6 @@
 <#import "parts/common.ftlh" as c>
+<#import "parts/authentication.ftlh" as auth>
+
 
 <@c.page>
     <h5>Join team by entering an invitation code</h5>
@@ -14,4 +16,17 @@
         <input type="hidden" name="_csrf" value="${_csrf.token}">
         <button class="btn btn-primary" type="submit">Join</button>
     </form>
+    <h5 class="text-dark mt-4">My teams</h5>
+    <div class="card-columns mt-2">
+        <#list teams as team>
+            <div class="card my-3">
+                <div class="m-2">
+                    <a class="nav-link" href="/practice/?team=${team.id}">${team.name}</a>
+                </div>
+                Creator: <b>${team.author.username}</b>
+            </div>
+        <#else>
+            No messages
+        </#list>
+    </div>
 </@c.page>


### PR DESCRIPTION
Closes #35 
Part of #34 
Show list of teams which include student on page for entering an invite code. Made redirection from this page to available practices by team.
Also, implemented checking credentials of user for viewing practice by id (e. g. `/practice/{practice.id}`).